### PR TITLE
Remove ruby version pinning and bump gem cache version

### DIFF
--- a/.github/workflows/jekyll.yaml
+++ b/.github/workflows/jekyll.yaml
@@ -37,9 +37,8 @@ jobs:
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          cache-version: 1 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

This change removes ruby version pinning from the Jekyll site publish workflow and bumps the gem cache version to invalidate caches.
