### PR TITLE
Keep track of useful tips in a howto.md doc

### DIFF
--- a/howto.md
+++ b/howto.md
@@ -1,0 +1,7 @@
+## Local development
+
+### Serve the site
+
+```bash
+bundle exec jekyll serve
+```


### PR DESCRIPTION
## Summary

This change keeps track of useful commands and tips related to jekyll in a `howto.md` doc.
